### PR TITLE
Direct Setup Configuration Task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,6 @@ dist-ssr/
 # OS files
 .DS_Store
 Thumbs.db
+
+# Docker
+docker-compose.override.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:15
+    container_name: atelier_resource_mgmt_db
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: atelier_resource_mgmt
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    restart: unless-stopped
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
- docker-compose.ymlを作成（PostgreSQL 15設定）
- .gitignoreにDocker関連の除外設定を追加
- PostgreSQL 16データベース環境を構築
- atelier_resource_mgmtデータベースを作成
- 開発環境での接続確認完了

注意: この環境ではDockerが利用できないため、
システムにインストール済みのPostgreSQL 16を使用。
開発用にlocalhost接続でtrust認証を有効化。