### PR TITLE
Implement TASK-0023 for Kairo

### DIFF
--- a/backend/src/controllers/customerController.ts
+++ b/backend/src/controllers/customerController.ts
@@ -20,7 +20,7 @@ export class CustomerController {
     const repositories = c.get('repositories') as IRepositoryContainer;
 
     // 🔵 Service を初期化（Repositoryを注入）
-    const customerService = new CustomerService(repositories.customerRepository);
+    const customerService = new CustomerService(repositories.customerRepository, repositories.cardRepository);
 
     try {
       // 🔵 Zodバリデーション
@@ -65,7 +65,7 @@ export class CustomerController {
    */
   static async getById(c: Context) {
     const repositories = c.get('repositories') as IRepositoryContainer;
-    const customerService = new CustomerService(repositories.customerRepository);
+    const customerService = new CustomerService(repositories.customerRepository, repositories.cardRepository);
 
     try {
       const id = c.req.param('id');
@@ -89,7 +89,7 @@ export class CustomerController {
    */
   static async create(c: Context) {
     const repositories = c.get('repositories') as IRepositoryContainer;
-    const customerService = new CustomerService(repositories.customerRepository);
+    const customerService = new CustomerService(repositories.customerRepository, repositories.cardRepository);
 
     try {
       const body = await c.req.json();
@@ -132,7 +132,7 @@ export class CustomerController {
    */
   static async update(c: Context) {
     const repositories = c.get('repositories') as IRepositoryContainer;
-    const customerService = new CustomerService(repositories.customerRepository);
+    const customerService = new CustomerService(repositories.customerRepository, repositories.cardRepository);
 
     try {
       const id = c.req.param('id');
@@ -173,7 +173,7 @@ export class CustomerController {
    */
   static async delete(c: Context) {
     const repositories = c.get('repositories') as IRepositoryContainer;
-    const customerService = new CustomerService(repositories.customerRepository);
+    const customerService = new CustomerService(repositories.customerRepository, repositories.cardRepository);
 
     try {
       const id = c.req.param('id');


### PR DESCRIPTION
## 実装内容
- CustomerServiceにrewardCardIdsの存在確認バリデーションを追加
  - 存在しないカードIDが指定された場合、ValidationError（VALID_001）を返す
  - createCustomerとupdateCustomerの両方に実装
- CustomerServiceにICardRepositoryを注入するように変更
- CustomerControllerで全メソッドのCustomerService初期化時にcardRepositoryを注入

## テストケース追加（POST /api/customers）
- 必須フィールドで顧客を作成できる
- rewardCardIdsでN:M関連付けできる
- difficulty範囲外でバリデーションエラー（0以下/6以上）
- 存在しないrewardCardIdで400エラー（VALID_001）
- 必須フィールドが欠けている場合にバリデーションエラー
- 作成後にrewardCardsを取得できる
- portraitUrlがnullでも正しく作成できる

## テスト結果
✓ 全13テストケースがパス

## 完了条件チェック
- [x] POST /api/customers が動作する
- [x] CustomerServiceを使用する
- [x] rewardCardIds指定でN:M関連付けできる
- [x] バリデーションエラー時に400エラー + VALID_001コードが返る
- [x] 存在しないrewardCardIdで400エラーが返る